### PR TITLE
Create docker-compose service for release verification

### DIFF
--- a/docker-compose.verify.yml
+++ b/docker-compose.verify.yml
@@ -1,0 +1,32 @@
+# The verification docker-compose file runs our services for the release-verification pipeline.
+# This is separate from the normal docker-compose as we mount node_modules as a volume in the verification process.
+version: '2.1'
+services:
+  fusion-server-verify:
+    extends:
+      file: docker-compose.yml
+      service: fusion-server
+    volumes:
+      - ./node_modules:/browser-tests/node_modules
+
+  chrome-standalone-verify:
+    extends:
+      file: docker-compose.yml
+      service: chrome-standalone
+
+  # wait for running server.
+  fusion-server-healthy-verify:
+    build: .
+    network_mode: "host"
+    depends_on:
+      fusion-server-verify:
+        condition: service_healthy
+
+  # For running verification integration tests in chrome
+  browser-test-chrome-verify:
+    build: .
+    network_mode: "host"
+    depends_on:
+      - chrome-standalone-verify
+      - fusion-server-healthy-verify
+    command: ./test-standalone.sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,17 +16,17 @@ services:
 
   chrome-standalone:
     image: selenium/standalone-chrome:latest@sha256:3c598426e44ba78c8289901cc095d787b18f4dcd69b5b75a366f2bfe503fcb7c
-    network_mode: "host"    
-    restart: always    
+    network_mode: "host"
+    restart: always
     ports:
       - "4444:4444"
 
   firefox-standalone:
     image: selenium/standalone-firefox:latest@sha256:4e8546d82e3d24d7f0289ae6586b5c9bd0d6ed16770fd0dfbbf0c6ddb05c0777
-    network_mode: "host"    
-    restart: always    
+    network_mode: "host"
+    restart: always
     ports:
-      - "4444:4444"      
+      - "4444:4444"
 
   sauce-tunnel:
     image: henrrich/docker-sauce-connect:latest@sha256:9921657d1a3db8832f868ab25491363756abae52025a8d5af888aadc42ed31e9
@@ -89,7 +89,7 @@ services:
     network_mode: "host"
     depends_on:
       - chrome-standalone
-      - fusion-server-healthy    
+      - fusion-server-healthy
     command: ./test-standalone.sh
 
   # For running integration tests locally in firefox
@@ -98,6 +98,6 @@ services:
     network_mode: "host"
     depends_on:
       - firefox-standalone
-      - fusion-server-healthy    
-    command: ./test-standalone.sh    
+      - fusion-server-healthy
+    command: ./test-standalone.sh
 

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
       "docker-compose down && docker-compose run browser-test-chrome",
     "test-firefox":
       "docker-compose down && docker-compose run browser-test-firefox",
+    "test-verification":
+      "docker-compose down && docker-compose -f docker-compose.verify.yml run browser-test-chrome-verify",
     "test": "./test-remotely.sh",
     "cover": "fusion test --cover",
     "source-map-explorer": "fusion source-map-explorer",


### PR DESCRIPTION
Related to: https://github.com/uber-workflow/fusion-release/issues/35

This is so we can mount a volume of the latest node_modules, instead of installing from npm within the container.

Fixes #116