### PR TITLE
Update browsers

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -32,8 +32,8 @@ steps:
         run: browser-tests-linters
     agents:
       queue: workers
-  - name: ':saucelabs: :selenium: :safari: 9'
-    command: ./test-remotely.sh safari-9
+  - name: ':saucelabs: :selenium: :safari: 10.1'
+    command: ./test-remotely.sh safari-10-1
     concurrency: 5
     concurrency_group: saucelabs
     plugins:
@@ -71,19 +71,6 @@ steps:
           - fusion-server-healthy
     agents:
       queue: workers
-  - name: ':saucelabs: :selenium: :ie: 9'
-    command: ./test-remotely.sh ie-9
-    concurrency: 5
-    concurrency_group: saucelabs
-    plugins:
-      'rtsao/docker-compose#e47c1ae':
-        run: browser-tests
-        pull:
-          - fusion-server
-          - sauce-tunnel-healthy
-          - fusion-server-healthy
-    agents:
-      queue: workers
   - name: ':saucelabs: :selenium: :ie: 11'
     command: ./test-remotely.sh ie-11
     concurrency: 5
@@ -97,8 +84,8 @@ steps:
           - fusion-server-healthy
     agents:
       queue: workers
-  - name: ':saucelabs: :selenium: :edge:'
-    command: ./test-remotely.sh edge
+  - name: ':saucelabs: :selenium: :edge: latest'
+    command: ./test-remotely.sh edge-latest
     concurrency: 5
     concurrency_group: saucelabs
     plugins:
@@ -110,8 +97,8 @@ steps:
           - fusion-server-healthy
     agents:
       queue: workers
-  - name: ':saucelabs: :selenium: :android: Samsung S3'
-    command: ./test-remotely.sh samsung-S3
+  - name: ':saucelabs: :selenium: :firefox: latest'
+    command: ./test-remotely.sh firefox-latest
     concurrency: 5
     concurrency_group: saucelabs
     plugins:
@@ -123,8 +110,8 @@ steps:
           - fusion-server-healthy
     agents:
       queue: workers
-  - name: ':saucelabs: :selenium: :android: Samsung G4'
-    command: ./test-remotely.sh samsung-G4
+  - name: ':saucelabs: :selenium: :firefox: previous'
+    command: ./test-remotely.sh firefox-previous
     concurrency: 5
     concurrency_group: saucelabs
     plugins:
@@ -136,21 +123,8 @@ steps:
           - fusion-server-healthy
     agents:
       queue: workers
-  - name: ':saucelabs: :selenium: :iphone: 5S'
-    command: ./test-remotely.sh iPhone-5s
-    concurrency: 5
-    concurrency_group: saucelabs
-    plugins:
-      'rtsao/docker-compose#e47c1ae':
-        run: browser-tests
-        pull:
-          - fusion-server
-          - sauce-tunnel-healthy
-          - fusion-server-healthy
-    agents:
-      queue: workers
-  - name: ':saucelabs: :selenium: Kindle Fire'
-    command: ./test-remotely.sh kindleFire
+  - name: ':saucelabs: :selenium: :firefox: 46'
+    command: ./test-remotely.sh firefox-46
     concurrency: 5
     concurrency_group: saucelabs
     plugins:

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,4 +13,4 @@ RUN yarn download-selenium
 
 COPY . .
 
-RUN yarn build
+RUN yarn build --production

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,9 @@ version: '2.1'
 services:
   fusion-server:
     build: .
-    command: yarn start --environment=development
+    command: yarn start
+    environment:
+      - NODE_ENV=production
     expose:
       - '3000'
     healthcheck:

--- a/package.json
+++ b/package.json
@@ -76,6 +76,9 @@
     "selenium-download": "^2.0.13",
     "tape": "^4.9.1"
   },
+  "resolutions": {
+    "fusion-plugin-i18n": "1.1.5-0"
+  },
   "engines": {
     "node": ">= 8.9.0"
   },

--- a/selenium-environments.js
+++ b/selenium-environments.js
@@ -9,92 +9,59 @@
 /* globals module */
 
 module.exports = {
-  'safari-11': {
+  'safari-10-1': {
     desiredCapabilities: {
       browserName: 'safari',
-      platform: 'macOS 10.12',
-      version: '11.0',
+      version: '10.1',
     },
   },
 
-  'safari-9': {
+  'safari-11': {
     desiredCapabilities: {
       browserName: 'safari',
-      platform: 'OS X 10.11',
-      version: '9.0',
+      version: '11',
     },
   },
 
   'safari-12': {
     desiredCapabilities: {
       browserName: 'safari',
-      platform: 'OS X 10.13',
-      version: '12.0',
-      extendedDebugging: true,
+      version: '12',
+    },
+  },
+
+  'edge-latest': {
+    desiredCapabilities: {
+      browserName: 'MicrosoftEdge',
+      version: 'latest',
+    },
+  },
+
+  'firefox-latest': {
+    desiredCapabilities: {
+      browserName: 'firefox',
+      version: 'latest',
+    },
+  },
+
+  'firefox-previous': {
+    desiredCapabilities: {
+      browserName: 'firefox',
+      version: 'latest-1',
+    },
+  },
+
+  'firefox-46': {
+    desiredCapabilities: {
+      browserName: 'firefox',
+      version: '46',
     },
   },
 
   'ie-11': {
     desiredCapabilities: {
       browserName: 'internet explorer',
-      platform: 'Windows 10',
-      version: '11.103',
-    },
-  },
-
-  'ie-9': {
-    desiredCapabilities: {
-      browserName: 'internet explorer',
-      platform: 'Windows 7',
-      version: '9.0',
-    },
-  },
-
-  'firefox-13': {
-    browserName: 'firefox',
-    platform: 'Windows 7',
-    version: '13.0',
-  },
-
-  edge: {
-    desiredCapabilities: {
-      browserName: 'MicrosoftEdge',
-    },
-  },
-
-  'samsung-S3': {
-    desiredCapabilities: {
-      browserName: 'Android',
-      deviceName: 'Samsung Galaxy S3 Emulator',
-      deviceOrientation: 'portrait',
-    },
-  },
-
-  'samsung-G4': {
-    desiredCapabilities: {
-      browserName: 'Android',
-      deviceName: 'Samsung Galaxy S4 GoogleAPI Emulator',
-      deviceOrientation: 'portrait',
-    },
-  },
-
-  'iPhone-5s': {
-    desiredCapabilities: {
-      browserName: 'Safari',
-      deviceName: 'iPhone 5s Simulator',
-      deviceOrientation: 'portrait',
-      platformVersion: '9.3',
-      platformName: 'iOS',
-    },
-  },
-
-  kindleFire: {
-    desiredCapabilities: {
-      browserName: 'Browser',
-      deviceName: 'Amazon Kindle Fire HD 8.9 GoogleAPI Emulator',
-      deviceOrientation: 'portrait',
-      platformVersion: '4.4',
-      platformName: 'Android',
+      version: '11',
     },
   },
 };

--- a/test-remotely.sh
+++ b/test-remotely.sh
@@ -7,18 +7,15 @@ then
 
   set -ex
 
-  nightwatch --config nightwatch-ci.js --env chrome-mac
-  nightwatch --config nightwatch-ci.js --env chrome-windows
-  nightwatch --config nightwatch-ci.js --env safari-9
+  nightwatch --config nightwatch-ci.js --env safari-10-3
   nightwatch --config nightwatch-ci.js --env safari-11
   nightwatch --config nightwatch-ci.js --env safari-12
-  nightwatch --config nightwatch-ci.js --env ie-9
+  nightwatch --config nightwatch-ci.js --env edge-latest
+  nightwatch --config nightwatch-ci.js --env firefox-latest
+  nightwatch --config nightwatch-ci.js --env firefox-previous
+  nightwatch --config nightwatch-ci.js --env firefox-46
   nightwatch --config nightwatch-ci.js --env ie-11
-  nightwatch --config nightwatch-ci.js --env edge
-  nightwatch --config nightwatch-ci.js --env samsung-S3
-  nightwatch --config nightwatch-ci.js --env samsung-G4
-  nightwatch --config nightwatch-ci.js --env iPhone-5s
-  nightwatch --config nightwatch-ci.js --env kindleFire
+
 else
   echo "### running tests against $1"
   nightwatch --config nightwatch-ci.js --env $1

--- a/yarn.lock
+++ b/yarn.lock
@@ -2743,6 +2743,10 @@ eslint-plugin-jest@^21.18.0, eslint-plugin-jest@^21.22.0, eslint-plugin-jest@^21
   version "21.24.1"
   resolved "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-21.24.1.tgz#aaf3c34e816f07add83d1e9c20696fdc31fac8dc"
 
+eslint-plugin-jest@^22.0.0:
+  version "22.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-22.0.0.tgz#87dc52bbdd47f37f23bf2b10bb8469458bb3ed68"
+
 eslint-plugin-prettier@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.0.0.tgz#f6b823e065f8c36529918cdb766d7a0e975ec30c"
@@ -3492,13 +3496,13 @@ fusion-plugin-i18n-react@^1.1.0:
     fusion-plugin-i18n "^1.1.1"
     prop-types "^15.6.2"
 
-fusion-plugin-i18n@^1.1.1:
-  version "1.1.2"
-  resolved "https://registry.npmjs.org/fusion-plugin-i18n/-/fusion-plugin-i18n-1.1.2.tgz#351e712ebc4c55b3d5c9cc99dc884f1764fd188f"
+fusion-plugin-i18n@1.1.5-0, fusion-plugin-i18n@^1.1.1:
+  version "1.1.5-0"
+  resolved "https://registry.yarnpkg.com/fusion-plugin-i18n/-/fusion-plugin-i18n-1.1.5-0.tgz#99a4b3bf776883d2e1bf2a17b7753043d901a558"
   dependencies:
-    eslint-plugin-jest "^21.24.1"
+    eslint-plugin-jest "^22.0.0"
     locale "^0.1.0"
-    rollup "^0.66.2"
+    rollup "^0.67.1"
 
 fusion-plugin-jwt@^1.0.6:
   version "1.0.6"
@@ -7250,9 +7254,9 @@ rollup@^0.64.0:
     "@types/estree" "0.0.39"
     "@types/node" "*"
 
-rollup@^0.66.2:
-  version "0.66.6"
-  resolved "https://registry.npmjs.org/rollup/-/rollup-0.66.6.tgz#ce7d6185beb7acea644ce220c25e71ae03275482"
+rollup@^0.67.1:
+  version "0.67.1"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-0.67.1.tgz#4094110c944d3c9e25b5bf196771b51132ec3adb"
   dependencies:
     "@types/estree" "0.0.39"
     "@types/node" "*"


### PR DESCRIPTION
- Test against production build/start instead of development.
- Add Firefox environments
- Remove Chrome tests (covered by Puppeteer)
- Add more Safari versions
- Remove old Android environments

It seems Sauce Labs doesn't support Samsung Internet yet unfortunately.